### PR TITLE
Fix comparisons

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -496,10 +496,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -318,8 +318,8 @@ class QuestionnaireController {
     // capture all top-level variables as list, in order
     final rootExpressions = (questionnaire.extension_ ?? [])
         .where((ext) =>
-            ext.url ==
-                FhirUri('http://hl7.org/fhir/StructureDefinition/variable') &&
+            ext.url.valueString ==
+                'http://hl7.org/fhir/StructureDefinition/variable' &&
             ext.valueExpression?.language.valueEnum ==
                 ExpressionLanguageEnum.textFhirpath)
         .toList();
@@ -385,9 +385,8 @@ class QuestionnaireController {
 
       final calculatedExpressions = (item.extension_ ?? [])
           .where((ext) =>
-              ext.url ==
-                  FhirUri(
-                      'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression') &&
+              ext.url.valueString ==
+                  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression' &&
               ext.valueExpression?.language.valueEnum ==
                   ExpressionLanguageEnum.textFhirpath)
           .toList()
@@ -446,9 +445,8 @@ class QuestionnaireController {
                   .extension_ ??
               [])
           .where((ext) =>
-              ext.url ==
-                  FhirUri(
-                      'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression') &&
+              ext.url.valueString ==
+                  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression' &&
               ext.valueExpression?.language.valueEnum ==
                   ExpressionLanguageEnum.textFhirpath)
           .toList();

--- a/lib/src/logic/utils/fhir_extension_utils.dart
+++ b/lib/src/logic/utils/fhir_extension_utils.dart
@@ -49,14 +49,14 @@ extension FhirExtensionUtils on Iterable<FhirExtension> {
     String langCode = locale.languageCode;
     final translation = firstWhereOrNull(
       (ext) =>
-          ext.url ==
-              FhirUri('http://hl7.org/fhir/StructureDefinition/translation') &&
+          ext.url.valueString ==
+              'http://hl7.org/fhir/StructureDefinition/translation' &&
           ext.extension_?.firstWhereOrNull((e) =>
-                  e.url == FhirUri('lang') &&
+                  e.url.valueString == 'lang' &&
                       e.valueCode?.valueString == langTag ||
                   e.valueCode?.valueString == langCode) !=
               null,
-    )?.extension_?.firstWhereOrNull((e) => e.url == FhirUri('content'));
+    )?.extension_?.firstWhereOrNull((e) => e.url.valueString == 'content');
 
     return translation?.valueString?.valueString ??
         translation?.valueMarkdown?.valueString;


### PR DESCRIPTION
After migration to fhir_r4 comparisons are failing (for example localize is not working anymore) because of the wrong comparing types. Urls are now stored as FhirString not FhirUrl, it is safest to unwrap it to String value and compare it like that