### PR TITLE
fix: localize questionnaire item title

### DIFF
--- a/lib/src/logic/utils/questionnaire_utils.dart
+++ b/lib/src/logic/utils/questionnaire_utils.dart
@@ -18,7 +18,8 @@ extension FhirTimeUtils on FhirTime {
 }
 
 extension QuestionnaireItemUtils on QuestionnaireItem {
-  String? get title => text?.valueString ?? code?.firstOrNull?.title;
+  String? get title =>
+      extension_?.localize() ?? text?.valueString ?? code?.firstOrNull?.title;
 }
 
 extension QuestionnaireUtils on Questionnaire {


### PR DESCRIPTION
## localize questionnaire item title

This PR fixes a regression in our localizations where we are no longer localizing questionnaire item titles.

This bug is _not_ present in the upstream fork (luis901101), but rather only in the fhir-fli fork that was pulled into this branch with the fhir_r4 migration.

There is an open pr from the fhir-fli fork to our upstream, and the maintainer has pointed out this bug https://github.com/luis901101/fhir_questionnaire/pull/19#discussion_r2406773367 , but it has not been resolved there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefer `extension_?.localize()` for `QuestionnaireItem.title` to restore localized titles over raw `text`/`code`.
> 
> - **Questionnaire utils**:
>   - `QuestionnaireItemUtils.title`: prioritize `extension_?.localize()` over `text`/`code` to return localized titles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f64056b1d39716917d6e6b8990d82dc399f2ce3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->